### PR TITLE
fix: TypeError bei Leistungs-Variablen durch wissenschaftliche Notation (Bezug #78)

### DIFF
--- a/solakon_one_nulleinspeisung.yaml
+++ b/solakon_one_nulleinspeisung.yaml
@@ -1069,15 +1069,15 @@ variables:
   grid_power: !input grid_power_sensor
   grid_power_float: >
     {% set v = states(grid_power) | float(0) %}
-    {{ v * 1000 if state_attr(grid_power, 'unit_of_measurement') == 'kW' else v }}
+    {{ ((v * 1000) if state_attr(grid_power, 'unit_of_measurement') == 'kW' else v) | round(3) }}
   solar_power: !input solar_power_sensor
   solar_power_float: >
     {% set v = states(solar_power) | float(0) %}
-    {{ v * 1000 if state_attr(solar_power, 'unit_of_measurement') == 'kW' else v }}
+    {{ ((v * 1000) if state_attr(solar_power, 'unit_of_measurement') == 'kW' else v) | round(3) }}
   actual_power_sensor: !input actual_power_sensor
   actual_power_float: >
     {% set v = states(actual_power_sensor) | float(0) %}
-    {{ v * 1000 if state_attr(actual_power_sensor, 'unit_of_measurement') == 'kW' else v }}
+    {{ ((v * 1000) if state_attr(actual_power_sensor, 'unit_of_measurement') == 'kW' else v) | round(3) }}
 
   # Zonen-Schwellwerte
   soc_fast_limit_static: !input soc_fast_limit
@@ -2357,10 +2357,10 @@ actions:
       # Frische Sensorwerte zum Zeitpunkt der PI-Berechnung (kW→W normalisiert)
       grid_power_float: >
         {% set v = states(grid_power) | float(0) %}
-        {{ v * 1000 if state_attr(grid_power, 'unit_of_measurement') == 'kW' else v }}
+        {{ ((v * 1000) if state_attr(grid_power, 'unit_of_measurement') == 'kW' else v) | round(3) }}
       solar_power_float: >
         {% set v = states(solar_power) | float(0) %}
-        {{ v * 1000 if state_attr(solar_power, 'unit_of_measurement') == 'kW' else v }}
+        {{ ((v * 1000) if state_attr(solar_power, 'unit_of_measurement') == 'kW' else v) | round(3) }}
 
       # Konfiguration
       wait_time_int: !input wait_time


### PR DESCRIPTION
## Problem

Die Automation bricht bei mir sporadisch ab — 75 Mal in 8 Tagen, immer mit derselben Meldung:

```
Solakon ONE Nulleinspeisung: Error executing script.
Error rendering template for variables at pos 6:
TypeError: unsupported operand type(s) for -: 'str' and 'float'
```

`pos 6` ist der Variablenblock direkt vor der PI-Berechnung. Die Automation steigt dort aus, bevor das PI-Script gerufen wird — in diesem Zyklus wird also nicht geregelt.

## Ursache

`grid_power_float`, `solar_power_float` und `actual_power_float` können als **String** statt als Zahl aus dem Rendervorgang kommen.

Home Assistant verzichtet in `_parse_result` bewusst auf `literal_eval`, wenn der gerenderte Text `e`, `E`, `j`, `J`, `inf` oder `nan` enthält — Schutz gegen das Fehlinterpretieren wissenschaftlicher Notation. Im Template-Editor nachvollziehbar:

```jinja
{{ 35.2 }}     →  35.2      (float)
{{ 0.00001 }}  →  "1e-05"   (str)
```

Werte unterhalb 1e-4 rendert Python in wissenschaftlicher Notation. Damit kippt der Typ still.

Mein Netz-Sensor ist die Summe der drei Phasen eines Shelly 3EM. Kürzen sich die Phasen weg, bleibt genau so ein Wert übrig:

```jinja
{{ 100.1 + 200.2 - 300.3 }}   →  -5.684341886080802e-14
{{ 0.1 + 0.2 - 0.3 }}         →   5.551115123125783e-17
{{ 45.67 - 12.3 - 33.37 }}    →   7.105427357601002e-15
```

Ist `grid_power_float` ein String, schlagen im Block vor der PI-Berechnung folgende Ausdrücke fehl:

```yaml
raw_error: "{{ grid_power_float - (target_offset | float(0)) }}"
grid_error_abs: "{{ (grid_power_float - (target_offset | float(0))) | abs }}"
```

Der rechte Operand ist mit `| float(0)` abgesichert, der linke nicht. Dasselbe Muster steckt in `dynamic_max_power` (`solar_power_float - (pv_charge_reserve_int | float(0))`) und — bei aktivierter Überschuss-Einspeisung — in den Fällen 0A/0B (`actual_power_float + grid_power_float ± surplus_pv_hysteresis_int`).

Das erklärt auch, warum es nur sporadisch auftritt: nur der seltene Durchgang durch das Band unterhalb 1e-4 löst es aus.

### Bezug zu #78

#78 ist dieselbe Fehlerklasse an anderer Stelle — dort driftete `input_number.solakon_integral` in wissenschaftliche Notation. Der Melder konnte den Mechanismus nur vermuten („Eine der Templating-Stellen kommt vermutlich nicht sauber mit Zahlen in wissenschaftlicher Notation klar"). Der oben gezeigte `_parse_result`-Filter ist diese Stelle. Es lohnt sich also, das Muster generell im Blick zu behalten: überall wo ein Template-Ergebnis später als Zahl weiterverrechnet wird, kann der Typ kippen.

## Änderung

`round(3)` auf die drei Produzenten, jeweils im Top-Level-`variables`-Block und im Block vor der PI-Berechnung (5 Stellen). Das beseitigt den Exponenten an der Quelle (`1.42e-14` → `0.0`) und wirkt damit für alle Konsumenten — statt jede einzelne Rechenstelle mit `| float(0)` nachzuziehen, wo beim nächsten neuen Ausdruck dieselbe Falle wieder offen wäre.

Bei Watt-Werten sind drei Dezimalstellen weit jenseits der Messgenauigkeit, die Regelung ändert sich dadurch nicht.

## Getestet

- HA 2026.8.2, Blueprint V308 im Einsatz; die betroffenen Zeilen sind in V309 unverändert
- YAML lädt nach der Änderung fehlerfrei, alle fünf Stellen greifen
- Ursache zusätzlich auf meiner Seite entschärft (Netz-Sensor rundet jetzt selbst) — der Blueprint sollte aber auch mit einem ungerundeten Sensor nicht abbrechen, daher dieser PR

---

<details>
<summary>English summary</summary>

`grid_power_float`, `solar_power_float` and `actual_power_float` can end up as **strings** instead of numbers: Home Assistant's `_parse_result` deliberately skips `literal_eval` when the rendered text contains `e`, `E`, `j`, `J`, `inf` or `nan`. Values below 1e-4 render in scientific notation, so the type silently flips — verify with `{{ 0.00001 }}` returning `"1e-05"` while `{{ 35.2 }}` returns `35.2`.

A grid sensor summing three phases produces exactly such residues when the phases cancel (e.g. `-5.68e-14`). Downstream, `raw_error: {{ grid_power_float - (target_offset | float(0)) }}` then raises `TypeError: unsupported operand type(s) for -: 'str' and 'float'`, aborting the automation before the PI call — no regulation for that cycle. 75 occurrences in 8 days here.

This PR adds `round(3)` to the three producer variables (5 locations), removing the exponent at the source so every consumer is covered. Same root-cause class as #78, different entry point. Three decimals on a watt value is well below measurement precision.

</details>
