### PR TITLE
Revert "fix: TypeError bei Leistungs-Variablen durch wissenschaftliche Notation (Bezug #78)"

### DIFF
--- a/solakon_one_nulleinspeisung.yaml
+++ b/solakon_one_nulleinspeisung.yaml
@@ -1069,15 +1069,15 @@ variables:
   grid_power: !input grid_power_sensor
   grid_power_float: >
     {% set v = states(grid_power) | float(0) %}
-    {{ ((v * 1000) if state_attr(grid_power, 'unit_of_measurement') == 'kW' else v) | round(3) }}
+    {{ v * 1000 if state_attr(grid_power, 'unit_of_measurement') == 'kW' else v }}
   solar_power: !input solar_power_sensor
   solar_power_float: >
     {% set v = states(solar_power) | float(0) %}
-    {{ ((v * 1000) if state_attr(solar_power, 'unit_of_measurement') == 'kW' else v) | round(3) }}
+    {{ v * 1000 if state_attr(solar_power, 'unit_of_measurement') == 'kW' else v }}
   actual_power_sensor: !input actual_power_sensor
   actual_power_float: >
     {% set v = states(actual_power_sensor) | float(0) %}
-    {{ ((v * 1000) if state_attr(actual_power_sensor, 'unit_of_measurement') == 'kW' else v) | round(3) }}
+    {{ v * 1000 if state_attr(actual_power_sensor, 'unit_of_measurement') == 'kW' else v }}
 
   # Zonen-Schwellwerte
   soc_fast_limit_static: !input soc_fast_limit
@@ -2357,10 +2357,10 @@ actions:
       # Frische Sensorwerte zum Zeitpunkt der PI-Berechnung (kW→W normalisiert)
       grid_power_float: >
         {% set v = states(grid_power) | float(0) %}
-        {{ ((v * 1000) if state_attr(grid_power, 'unit_of_measurement') == 'kW' else v) | round(3) }}
+        {{ v * 1000 if state_attr(grid_power, 'unit_of_measurement') == 'kW' else v }}
       solar_power_float: >
         {% set v = states(solar_power) | float(0) %}
-        {{ ((v * 1000) if state_attr(solar_power, 'unit_of_measurement') == 'kW' else v) | round(3) }}
+        {{ v * 1000 if state_attr(solar_power, 'unit_of_measurement') == 'kW' else v }}
 
       # Konfiguration
       wait_time_int: !input wait_time


### PR DESCRIPTION
Reverts D4nte85/Solakon-One-Nulleinspeisung-Blueprint-homeassistant#83